### PR TITLE
Support caching of provider API data via bucketing

### DIFF
--- a/provider/README.md
+++ b/provider/README.md
@@ -81,10 +81,10 @@ A trip represents a journey taken by a *mobility as a service* customer with a g
 
 The trips API allows a user to query historical trip data.
 
-Endpoint: `/trips/{bucket_duration}/{min_end_time}`
-Method: `GET`
-Schema: [`trips` schema][trips-schema]
-`data` Payload: `{ "trips": [] }`, an array of objects with the following structure
+Endpoint: `/trips/{bucket_duration}/{min_end_time}`  
+Method: `GET`  
+Schema: [`trips` schema][trips-schema]  
+`data` Payload: `{ "trips": [] }`, an array of objects with the following structure  
 
 
 | Field | Type    | Required/Optional | Comments |
@@ -233,8 +233,8 @@ For example, 1 hour bucket would look like this:
 
 Gets the list of service areas available to the provider.
 
-Endpoint: `/service_areas`
-Method: `GET`
+Endpoint: `/service_areas`  
+Method: `GET`  
 Query Parameters:
 
 | Parameter | Type | Required/Optional | Description |

--- a/provider/README.md
+++ b/provider/README.md
@@ -233,8 +233,8 @@ For example, 1 hour bucket would look like this:
 
 Gets the list of service areas available to the provider.
 
-Endpoint: `/service_areas`  
-Method: `GET`  
+Endpoint: `/service_areas`
+Method: `GET`
 Query Parameters:
 
 | Parameter | Type | Required/Optional | Description |

--- a/provider/README.md
+++ b/provider/README.md
@@ -108,7 +108,7 @@ Schema: [`trips` schema][trips-schema]
 
 ### URL Parameters
 
-In order to support caching of data, the Provider and Agency should agree upon a time interval for bucketing of data.
+In order to support caching of data, the Provider and Agency should agree upon a fixed time interval for bucketing.
 
 | Field | Type | Comments |
 | ----- | ---- | -------- |
@@ -118,6 +118,8 @@ In order to support caching of data, the Provider and Agency should agree upon a
 For example, 1 hour bucket would look like this:
  - `GET /trips/3600/1543352400` Nov 27, 9pm UTC
  - `GET /trips/3600/1543356000` Nov 27, 10pm UTC
+
+If the data for the bucket is not yet prepared, a 404 HTTP Status Code should be returned. The Agency should retry the request at a later time. The Provider and Agency should agree upon an SLA around when data should be ready (e.g. 3 minutes after the hour).
 
 ### Vehicle Types
 
@@ -203,7 +205,7 @@ Schema: [`status_changes` schema][sc-schema]
 
 ### URL Parameters
 
-In order to support caching of data, the Provider and Agency should agree upon a time interval for bucketing of data.
+In order to support caching of data, the Provider and Agency should agree upon a fixed time interval for bucketing.
 
 | Field | Type | Comments |
 | ----- | ---- | -------- |
@@ -213,6 +215,8 @@ In order to support caching of data, the Provider and Agency should agree upon a
 For example, 1 hour bucket would look like this:
  - `GET /status_changes/3600/1543352400` Nov 27, 9pm UTC
  - `GET /status_changes/3600/1543356000` Nov 27, 10pm UTC
+
+If the data for the bucket is not yet prepared, a 404 HTTP Status Code should be returned. The Agency should retry the request at a later time. The Provider and Agency should agree upon an SLA around when data should be ready (e.g. 3 minutes after the hour).
 
 ### Event Types
 

--- a/provider/README.md
+++ b/provider/README.md
@@ -182,8 +182,8 @@ The status of the inventory of vehicles available for customer use.
 This API allows a user to query the historical availability for a system within a time range.
 
 Endpoint: `/status_changes/{bucket_duration}/{min_event_time}`
-Method: `GET`
-Schema: [`status_changes` schema][sc-schema]
+Method: `GET`  
+Schema: [`status_changes` schema][sc-schema]  
 `data` Payload: `{ "status_changes": [] }`, an array of objects with the following structure
 
 | Field | Type | Required/Optional | Comments |

--- a/provider/README.md
+++ b/provider/README.md
@@ -181,7 +181,7 @@ The status of the inventory of vehicles available for customer use.
 
 This API allows a user to query the historical availability for a system within a time range.
 
-Endpoint: `/status_changes/{bucket_duration}/{min_event_time}`
+Endpoint: `/status_changes/{bucket_duration}/{min_event_time}`  
 Method: `GET`  
 Schema: [`status_changes` schema][sc-schema]  
 `data` Payload: `{ "status_changes": [] }`, an array of objects with the following structure


### PR DESCRIPTION
**Issue**
With the current design of the MDS Provider API, Providers are required to maintain a production database designed specifically for serving MDS data. It is difficult to predict how and when the database will be queried, creating maintenance overhead for Providers.

If we restrict the way data is queried, we could cache data instead of needing to query a database synchronously.

Why would we want caching?
- Response times would go from seconds to milliseconds. This would make for fast and easy backfills.
- Providers could query a data warehouse asynchronously instead of needing to set up a database specifically for MDS.
- No need to maintain complex indexes with respect bounding boxes.
- Pagination could be removed as large files could be returned.

**Proposal**
- Bucket trip and status change data (by the hour, for example).
- Remove `bbox`. Provider + Agency should agree upon a bounding box in advance.
- Remove pagination.
- Document policy if a bucket is not yet prepared.